### PR TITLE
Return length from files  download, thumbnail, and preview methods

### DIFF
--- a/client.go
+++ b/client.go
@@ -43,21 +43,22 @@ func (c *Client) call(path string, in interface{}) (io.ReadCloser, error) {
 	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
 	req.Header.Set("Content-Type", "application/json")
 
-	return c.do(req)
+	r, _, err := c.do(req)
+	return r, err
 }
 
 // download style endpoint.
-func (c *Client) download(path string, in interface{}, r io.Reader) (io.ReadCloser, error) {
+func (c *Client) download(path string, in interface{}, r io.Reader) (io.ReadCloser, int64, error) {
 	url := "https://content.dropboxapi.com/2" + path
 
 	body, err := json.Marshal(in)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	req, err := http.NewRequest("POST", url, r)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	req.Header.Set("Authorization", "Bearer "+c.AccessToken)
 	req.Header.Set("Dropbox-API-Arg", string(body))
@@ -70,14 +71,14 @@ func (c *Client) download(path string, in interface{}, r io.Reader) (io.ReadClos
 }
 
 // perform the request.
-func (c *Client) do(req *http.Request) (io.ReadCloser, error) {
+func (c *Client) do(req *http.Request) (io.ReadCloser, int64, error) {
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	if res.StatusCode < 400 {
-		return res.Body, err
+		return res.Body, res.ContentLength, err
 	}
 
 	defer res.Body.Close()
@@ -92,15 +93,15 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, error) {
 	if strings.Contains(kind, "text/plain") {
 		if b, err := ioutil.ReadAll(res.Body); err == nil {
 			e.Summary = string(b)
-			return nil, e
+			return nil, 0, e
 		} else {
-			return nil, err
+			return nil, 0, err
 		}
 	}
 
 	if err := json.NewDecoder(res.Body).Decode(e); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return nil, e
+	return nil, 0, e
 }

--- a/files.go
+++ b/files.go
@@ -320,7 +320,7 @@ type UploadOutput struct {
 
 // Upload a file smaller than 150MB.
 func (c *Files) Upload(in *UploadInput) (out *UploadOutput, err error) {
-	body, err := c.download("/files/upload", in, in.Reader)
+	body, _, err := c.download("/files/upload", in, in.Reader)
 	if err != nil {
 		return
 	}
@@ -337,17 +337,18 @@ type DownloadInput struct {
 
 // DownloadOutput request output.
 type DownloadOutput struct {
-	Body io.ReadCloser
+	Body   io.ReadCloser
+	Length int64
 }
 
 // Download a file.
 func (c *Files) Download(in *DownloadInput) (out *DownloadOutput, err error) {
-	body, err := c.download("/files/download", in, nil)
+	body, l, err := c.download("/files/download", in, nil)
 	if err != nil {
 		return
 	}
 
-	out = &DownloadOutput{body}
+	out = &DownloadOutput{body, l}
 	return
 }
 
@@ -386,18 +387,19 @@ type GetThumbnailInput struct {
 
 // GetThumbnailOutput request output.
 type GetThumbnailOutput struct {
-	Body io.ReadCloser
+	Body   io.ReadCloser
+	Length int64
 }
 
 // GetThumbnail a thumbnail for a file. Currently thumbnails are only generated for the
 // files with the following extensions: png, jpeg, png, tiff, tif, gif and bmp.
 func (c *Files) GetThumbnail(in *GetThumbnailInput) (out *GetThumbnailOutput, err error) {
-	body, err := c.download("/files/get_thumbnail", in, nil)
+	body, l, err := c.download("/files/get_thumbnail", in, nil)
 	if err != nil {
 		return
 	}
 
-	out = &GetThumbnailOutput{body}
+	out = &GetThumbnailOutput{body, l}
 	return
 }
 
@@ -408,19 +410,20 @@ type GetPreviewInput struct {
 
 // GetPreviewOutput request output.
 type GetPreviewOutput struct {
-	Body io.ReadCloser
+	Body   io.ReadCloser
+	Length int64
 }
 
 // GetPreview a preview for a file. Currently previews are only generated for the
 // files with the following extensions: .doc, .docx, .docm, .ppt, .pps, .ppsx,
 // .ppsm, .pptx, .pptm, .xls, .xlsx, .xlsm, .rtf
 func (c *Files) GetPreview(in *GetPreviewInput) (out *GetPreviewOutput, err error) {
-	body, err := c.download("/files/get_preview", in, nil)
+	body, l, err := c.download("/files/get_preview", in, nil)
 	if err != nil {
 		return
 	}
 
-	out = &GetPreviewOutput{body}
+	out = &GetPreviewOutput{body, l}
 	return
 }
 

--- a/files_test.go
+++ b/files_test.go
@@ -35,6 +35,10 @@ func TestFiles_Download(t *testing.T) {
 	assert.NoError(t, err, "error downloading")
 	defer out.Body.Close()
 
+	fi, err := os.Lstat("Readme.md")
+	assert.NoError(t, err, "error getting local file info")
+	assert.Equal(t, fi.Size(), out.Length, "Readme.md length mismatch")
+
 	remote, err := ioutil.ReadAll(out.Body)
 	assert.NoError(t, err, "error reading remote")
 
@@ -142,6 +146,8 @@ func TestFiles_GetThumbnail(t *testing.T) {
 	}
 	defer out.Body.Close()
 
+	assert.NotEmpty(t, out.Length, "length should not be 0")
+
 	buf := make([]byte, 11)
 	_, err = out.Body.Read(buf)
 	assert.NoError(t, err)
@@ -158,6 +164,8 @@ func TestFiles_GetPreview(t *testing.T) {
 	defer out.Body.Close()
 
 	assert.NoError(t, err)
+
+	assert.NotEmpty(t, out.Length, "length should not be 0")
 
 	buf := make([]byte, 4)
 	_, err = out.Body.Read(buf)


### PR DESCRIPTION
Passing the response content length of download, thumbnail, and preview requests to the API user enables calculating progress, e.g., when streaming the bits to a HTTP connection.
