### PR TITLE
Add HTTP result header to file result types

### DIFF
--- a/files.go
+++ b/files.go
@@ -51,7 +51,7 @@ type GetMetadataInput struct {
 // GetMetadataOutput request output.
 type GetMetadataOutput struct {
 	Metadata
-	Header http.Header
+	RequestID string
 }
 
 // GetMetadata returns the metadata for a file or folder.
@@ -64,7 +64,7 @@ func (c *Files) GetMetadata(in *GetMetadataInput) (out *GetMetadataOutput, err e
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -79,7 +79,7 @@ type CreateFolderOutput struct {
 	Name      string `json:"name"`
 	PathLower string `json:"path_lower"`
 	ID        string `json:"id"`
-	Header    http.Header
+	RequestID string
 }
 
 // CreateFolder creates a folder.
@@ -92,7 +92,7 @@ func (c *Files) CreateFolder(in *CreateFolderInput) (out *CreateFolderOutput, er
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -105,7 +105,7 @@ type DeleteInput struct {
 // DeleteOutput request output.
 type DeleteOutput struct {
 	Metadata
-	Header http.Header
+	RequestID string
 }
 
 // Delete a file or folder and its contents.
@@ -118,7 +118,7 @@ func (c *Files) Delete(in *DeleteInput) (out *DeleteOutput, err error) {
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -148,7 +148,7 @@ type CopyInput struct {
 // CopyOutput request output.
 type CopyOutput struct {
 	Metadata
-	Header http.Header
+	RequestID string
 }
 
 // Copy a file or folder to a different location.
@@ -161,7 +161,7 @@ func (c *Files) Copy(in *CopyInput) (out *CopyOutput, err error) {
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -175,7 +175,7 @@ type MoveInput struct {
 // MoveOutput request output.
 type MoveOutput struct {
 	Metadata
-	Header http.Header
+	RequestID string
 }
 
 // Move a file or folder to a different location.
@@ -188,7 +188,7 @@ func (c *Files) Move(in *MoveInput) (out *MoveOutput, err error) {
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -202,7 +202,7 @@ type RestoreInput struct {
 // RestoreOutput request output.
 type RestoreOutput struct {
 	Metadata
-	Header http.Header
+	RequestID string
 }
 
 // Restore a file to a specific revision.
@@ -215,7 +215,7 @@ func (c *Files) Restore(in *RestoreInput) (out *RestoreOutput, err error) {
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -230,10 +230,10 @@ type ListFolderInput struct {
 
 // ListFolderOutput request output.
 type ListFolderOutput struct {
-	Cursor  string `json:"cursor"`
-	HasMore bool   `json:"has_more"`
-	Entries []*Metadata
-	Header  http.Header
+	Cursor    string `json:"cursor"`
+	HasMore   bool   `json:"has_more"`
+	Entries   []*Metadata
+	RequestID string
 }
 
 // ListFolder returns the metadata for a file or folder.
@@ -248,7 +248,7 @@ func (c *Files) ListFolder(in *ListFolderInput) (out *ListFolderOutput, err erro
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -268,7 +268,7 @@ func (c *Files) ListFolderContinue(in *ListFolderContinueInput) (out *ListFolder
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -312,10 +312,10 @@ type SearchInput struct {
 
 // SearchOutput request output.
 type SearchOutput struct {
-	Matches []*SearchMatch `json:"matches"`
-	More    bool           `json:"more"`
-	Start   uint64         `json:"start"`
-	Header  http.Header
+	Matches   []*SearchMatch `json:"matches"`
+	More      bool           `json:"more"`
+	Start     uint64         `json:"start"`
+	RequestID string
 }
 
 // Search for files and folders.
@@ -334,7 +334,7 @@ func (c *Files) Search(in *SearchInput) (out *SearchOutput, err error) {
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -352,7 +352,7 @@ type UploadInput struct {
 // UploadOutput request output.
 type UploadOutput struct {
 	Metadata
-	Header http.Header
+	RequestID string
 }
 
 // Upload a file smaller than 150MB.
@@ -365,7 +365,7 @@ func (c *Files) Upload(in *UploadInput) (out *UploadOutput, err error) {
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -377,9 +377,10 @@ type DownloadInput struct {
 
 // DownloadOutput request output.
 type DownloadOutput struct {
-	Body   io.ReadCloser
-	Length int64
-	Header http.Header
+	Body      io.ReadCloser
+	Length    int64
+	RequestID string
+	APIResult *Metadata
 }
 
 // Download a file.
@@ -389,7 +390,7 @@ func (c *Files) Download(in *DownloadInput) (out *DownloadOutput, err error) {
 		return
 	}
 
-	out = &DownloadOutput{body, l, hdr}
+	out = &DownloadOutput{body, l, hdr.Get("X-Dropbox-Request-Id"), unmarshalDropboxApiResult(hdr)}
 	return
 }
 
@@ -428,9 +429,10 @@ type GetThumbnailInput struct {
 
 // GetThumbnailOutput request output.
 type GetThumbnailOutput struct {
-	Body   io.ReadCloser
-	Length int64
-	Header http.Header
+	Body      io.ReadCloser
+	Length    int64
+	RequestID string
+	APIResult *Metadata
 }
 
 // GetThumbnail a thumbnail for a file. Currently thumbnails are only generated for the
@@ -441,7 +443,7 @@ func (c *Files) GetThumbnail(in *GetThumbnailInput) (out *GetThumbnailOutput, er
 		return
 	}
 
-	out = &GetThumbnailOutput{body, l, hdr}
+	out = &GetThumbnailOutput{body, l, hdr.Get("X-Dropbox-Request-Id"), unmarshalDropboxApiResult(hdr)}
 	return
 }
 
@@ -452,9 +454,10 @@ type GetPreviewInput struct {
 
 // GetPreviewOutput request output.
 type GetPreviewOutput struct {
-	Body   io.ReadCloser
-	Length int64
-	Header http.Header
+	Body      io.ReadCloser
+	Length    int64
+	RequestID string
+	APIResult *Metadata
 }
 
 // GetPreview a preview for a file. Currently previews are only generated for the
@@ -466,7 +469,7 @@ func (c *Files) GetPreview(in *GetPreviewInput) (out *GetPreviewOutput, err erro
 		return
 	}
 
-	out = &GetPreviewOutput{body, l, hdr}
+	out = &GetPreviewOutput{body, l, hdr.Get("X-Dropbox-Request-Id"), unmarshalDropboxApiResult(hdr)}
 	return
 }
 
@@ -480,7 +483,7 @@ type ListRevisionsInput struct {
 type ListRevisionsOutput struct {
 	IsDeleted bool
 	Entries   []*Metadata
-	Header    http.Header
+	RequestID string
 }
 
 // ListRevisions gets the revisions of the specified file.
@@ -493,7 +496,7 @@ func (c *Files) ListRevisions(in *ListRevisionsInput) (out *ListRevisionsOutput,
 
 	err = json.NewDecoder(body).Decode(&out)
 	if err == nil {
-		out.Header = hdr
+		out.RequestID = hdr.Get("X-Dropbox-Request-Id")
 	}
 	return
 }
@@ -507,9 +510,9 @@ func normalizePath(s string) string {
 	}
 }
 
-// UnmarshalDropboxApiResult unmarshals the Dropbox-Api-Result header.
-func UnmarshalDropboxApiResult(header http.Header) *Metadata {
-	v := header.Get("Dropbox-Api-Result")
+// unmarshalDropboxApiResult unmarshals the Dropbox-Api-Result header.
+func unmarshalDropboxApiResult(hdr http.Header) *Metadata {
+	v := hdr.Get("Dropbox-Api-Result")
 	if v == "" {
 		return nil
 	}

--- a/files.go
+++ b/files.go
@@ -3,6 +3,7 @@ package dropbox
 import (
 	"encoding/json"
 	"io"
+	"net/http"
 	"time"
 )
 
@@ -50,17 +51,21 @@ type GetMetadataInput struct {
 // GetMetadataOutput request output.
 type GetMetadataOutput struct {
 	Metadata
+	Header http.Header
 }
 
 // GetMetadata returns the metadata for a file or folder.
 func (c *Files) GetMetadata(in *GetMetadataInput) (out *GetMetadataOutput, err error) {
-	body, err := c.call("/files/get_metadata", in)
+	body, hdr, err := c.call("/files/get_metadata", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -74,17 +79,21 @@ type CreateFolderOutput struct {
 	Name      string `json:"name"`
 	PathLower string `json:"path_lower"`
 	ID        string `json:"id"`
+	Header    http.Header
 }
 
 // CreateFolder creates a folder.
 func (c *Files) CreateFolder(in *CreateFolderInput) (out *CreateFolderOutput, err error) {
-	body, err := c.call("/files/create_folder", in)
+	body, hdr, err := c.call("/files/create_folder", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -96,17 +105,21 @@ type DeleteInput struct {
 // DeleteOutput request output.
 type DeleteOutput struct {
 	Metadata
+	Header http.Header
 }
 
 // Delete a file or folder and its contents.
 func (c *Files) Delete(in *DeleteInput) (out *DeleteOutput, err error) {
-	body, err := c.call("/files/delete", in)
+	body, hdr, err := c.call("/files/delete", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -117,7 +130,7 @@ type PermanentlyDeleteInput struct {
 
 // PermanentlyDelete a file or folder and its contents.
 func (c *Files) PermanentlyDelete(in *PermanentlyDeleteInput) (err error) {
-	body, err := c.call("/files/delete", in)
+	body, _, err := c.call("/files/delete", in)
 	if err != nil {
 		return
 	}
@@ -135,17 +148,21 @@ type CopyInput struct {
 // CopyOutput request output.
 type CopyOutput struct {
 	Metadata
+	Header http.Header
 }
 
 // Copy a file or folder to a different location.
 func (c *Files) Copy(in *CopyInput) (out *CopyOutput, err error) {
-	body, err := c.call("/files/copy", in)
+	body, hdr, err := c.call("/files/copy", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -158,17 +175,21 @@ type MoveInput struct {
 // MoveOutput request output.
 type MoveOutput struct {
 	Metadata
+	Header http.Header
 }
 
 // Move a file or folder to a different location.
 func (c *Files) Move(in *MoveInput) (out *MoveOutput, err error) {
-	body, err := c.call("/files/move", in)
+	body, hdr, err := c.call("/files/move", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -181,17 +202,21 @@ type RestoreInput struct {
 // RestoreOutput request output.
 type RestoreOutput struct {
 	Metadata
+	Header http.Header
 }
 
 // Restore a file to a specific revision.
 func (c *Files) Restore(in *RestoreInput) (out *RestoreOutput, err error) {
-	body, err := c.call("/files/restore", in)
+	body, hdr, err := c.call("/files/restore", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -208,19 +233,23 @@ type ListFolderOutput struct {
 	Cursor  string `json:"cursor"`
 	HasMore bool   `json:"has_more"`
 	Entries []*Metadata
+	Header  http.Header
 }
 
 // ListFolder returns the metadata for a file or folder.
 func (c *Files) ListFolder(in *ListFolderInput) (out *ListFolderOutput, err error) {
 	in.Path = normalizePath(in.Path)
 
-	body, err := c.call("/files/list_folder", in)
+	body, hdr, err := c.call("/files/list_folder", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -231,13 +260,16 @@ type ListFolderContinueInput struct {
 
 // ListFolderContinue pagenates using the cursor from ListFolder.
 func (c *Files) ListFolderContinue(in *ListFolderContinueInput) (out *ListFolderOutput, err error) {
-	body, err := c.call("/files/list_folder/continue", in)
+	body, hdr, err := c.call("/files/list_folder/continue", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -283,6 +315,7 @@ type SearchOutput struct {
 	Matches []*SearchMatch `json:"matches"`
 	More    bool           `json:"more"`
 	Start   uint64         `json:"start"`
+	Header  http.Header
 }
 
 // Search for files and folders.
@@ -293,13 +326,16 @@ func (c *Files) Search(in *SearchInput) (out *SearchOutput, err error) {
 		in.Mode = SearchModeFilename
 	}
 
-	body, err := c.call("/files/search", in)
+	body, hdr, err := c.call("/files/search", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -316,17 +352,21 @@ type UploadInput struct {
 // UploadOutput request output.
 type UploadOutput struct {
 	Metadata
+	Header http.Header
 }
 
 // Upload a file smaller than 150MB.
 func (c *Files) Upload(in *UploadInput) (out *UploadOutput, err error) {
-	body, _, err := c.download("/files/upload", in, in.Reader)
+	body, _, hdr, err := c.download("/files/upload", in, in.Reader)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -339,16 +379,17 @@ type DownloadInput struct {
 type DownloadOutput struct {
 	Body   io.ReadCloser
 	Length int64
+	Header http.Header
 }
 
 // Download a file.
 func (c *Files) Download(in *DownloadInput) (out *DownloadOutput, err error) {
-	body, l, err := c.download("/files/download", in, nil)
+	body, l, hdr, err := c.download("/files/download", in, nil)
 	if err != nil {
 		return
 	}
 
-	out = &DownloadOutput{body, l}
+	out = &DownloadOutput{body, l, hdr}
 	return
 }
 
@@ -389,17 +430,18 @@ type GetThumbnailInput struct {
 type GetThumbnailOutput struct {
 	Body   io.ReadCloser
 	Length int64
+	Header http.Header
 }
 
 // GetThumbnail a thumbnail for a file. Currently thumbnails are only generated for the
 // files with the following extensions: png, jpeg, png, tiff, tif, gif and bmp.
 func (c *Files) GetThumbnail(in *GetThumbnailInput) (out *GetThumbnailOutput, err error) {
-	body, l, err := c.download("/files/get_thumbnail", in, nil)
+	body, l, hdr, err := c.download("/files/get_thumbnail", in, nil)
 	if err != nil {
 		return
 	}
 
-	out = &GetThumbnailOutput{body, l}
+	out = &GetThumbnailOutput{body, l, hdr}
 	return
 }
 
@@ -412,18 +454,19 @@ type GetPreviewInput struct {
 type GetPreviewOutput struct {
 	Body   io.ReadCloser
 	Length int64
+	Header http.Header
 }
 
 // GetPreview a preview for a file. Currently previews are only generated for the
 // files with the following extensions: .doc, .docx, .docm, .ppt, .pps, .ppsx,
 // .ppsm, .pptx, .pptm, .xls, .xlsx, .xlsm, .rtf
 func (c *Files) GetPreview(in *GetPreviewInput) (out *GetPreviewOutput, err error) {
-	body, l, err := c.download("/files/get_preview", in, nil)
+	body, l, hdr, err := c.download("/files/get_preview", in, nil)
 	if err != nil {
 		return
 	}
 
-	out = &GetPreviewOutput{body, l}
+	out = &GetPreviewOutput{body, l, hdr}
 	return
 }
 
@@ -437,17 +480,21 @@ type ListRevisionsInput struct {
 type ListRevisionsOutput struct {
 	IsDeleted bool
 	Entries   []*Metadata
+	Header    http.Header
 }
 
 // ListRevisions gets the revisions of the specified file.
 func (c *Files) ListRevisions(in *ListRevisionsInput) (out *ListRevisionsOutput, err error) {
-	body, err := c.call("/files/list_revisions", in)
+	body, hdr, err := c.call("/files/list_revisions", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 

--- a/files.go
+++ b/files.go
@@ -506,3 +506,17 @@ func normalizePath(s string) string {
 		return s
 	}
 }
+
+// UnmarshalDropboxApiResult unmarshals the Dropbox-Api-Result header.
+func UnmarshalDropboxApiResult(header http.Header) *Metadata {
+	v := header.Get("Dropbox-Api-Result")
+	if v == "" {
+		return nil
+	}
+	var m Metadata
+	err := json.Unmarshal([]byte(v), &m)
+	if err != nil {
+		return nil
+	}
+	return &m
+}

--- a/files_test.go
+++ b/files_test.go
@@ -194,7 +194,7 @@ func TestFiles_UnmarshalDropboxApiResultNotSet(t *testing.T) {
 		"X-Robots-Tag":           []string{"noindex", "nofollow", "noimageindex"},
 	}
 
-	v := UnmarshalDropboxApiResult(hdr)
+	v := unmarshalDropboxApiResult(hdr)
 
 	assert.Empty(t, v)
 }
@@ -210,7 +210,7 @@ func TestFiles_UnmarshalDropboxApiResultSet(t *testing.T) {
 		"X-Robots-Tag":           []string{"noindex", "nofollow", "noimageindex"},
 	}
 
-	v := UnmarshalDropboxApiResult(hdr)
+	v := unmarshalDropboxApiResult(hdr)
 
 	assert.NotEmpty(t, v)
 	assert.Equal(t, "id:dxYX4OTicUAAAAAAAAATzA", v.ID)

--- a/files_test.go
+++ b/files_test.go
@@ -3,6 +3,7 @@ package dropbox
 import (
 	"bytes"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"testing"
 
@@ -181,4 +182,36 @@ func TestFiles_ListRevisions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, out.Entries)
 	assert.False(t, out.IsDeleted)
+}
+
+func TestFiles_UnmarshalDropboxApiResultNotSet(t *testing.T) {
+	hdr := http.Header{
+		"Date":                   []string{"Wed, 13 Jan 2016 03:14:59 GMT"},
+		"Content-Length":         []string{"808"},
+		"Server":                 []string{"nginx"},
+		"X-Server-Response-Time": []string{"740"},
+		"X-Dropbox-Request-Id":   []string{"2053baf502dc4d4d64f2201a12f0ce26"},
+		"X-Robots-Tag":           []string{"noindex", "nofollow", "noimageindex"},
+	}
+
+	v := UnmarshalDropboxApiResult(hdr)
+
+	assert.Empty(t, v)
+}
+
+func TestFiles_UnmarshalDropboxApiResultSet(t *testing.T) {
+	hdr := http.Header{
+		"Date":                   []string{"Wed, 13 Jan 2016 03:14:59 GMT"},
+		"Content-Length":         []string{"808"},
+		"Server":                 []string{"nginx"},
+		"Dropbox-Api-Result":     []string{`{"name": "Readme.md", "path_lower": "/readme.md", "id": "id:dxYX4OTicUAAAAAAAAATzA", "client_modified": "2001-01-01T00:00:00Z", "server_modified": "2016-01-13T21:42:37Z", "rev": "14a4406950f6", "size": 808}`},
+		"X-Server-Response-Time": []string{"740"},
+		"X-Dropbox-Request-Id":   []string{"2053baf502dc4d4d64f2201a12f0ce26"},
+		"X-Robots-Tag":           []string{"noindex", "nofollow", "noimageindex"},
+	}
+
+	v := UnmarshalDropboxApiResult(hdr)
+
+	assert.NotEmpty(t, v)
+	assert.Equal(t, "id:dxYX4OTicUAAAAAAAAATzA", v.ID)
 }

--- a/files_test.go
+++ b/files_test.go
@@ -39,6 +39,7 @@ func TestFiles_Download(t *testing.T) {
 	fi, err := os.Lstat("Readme.md")
 	assert.NoError(t, err, "error getting local file info")
 	assert.Equal(t, fi.Size(), out.Length, "Readme.md length mismatch")
+	assert.NotEmpty(t, out.APIResult)
 
 	remote, err := ioutil.ReadAll(out.Body)
 	assert.NoError(t, err, "error reading remote")
@@ -156,6 +157,7 @@ func TestFiles_GetThumbnail(t *testing.T) {
 		0xff, 0xd8, // JPEG SOI marker
 		0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, // JFIF tag
 	}, buf, "should have jpeg header")
+	assert.NotEmpty(t, out.APIResult)
 }
 
 func TestFiles_GetPreview(t *testing.T) {
@@ -172,6 +174,7 @@ func TestFiles_GetPreview(t *testing.T) {
 	_, err = out.Body.Read(buf)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte{0x25, 0x50, 0x44, 0x46}, buf, "should have pdf magic number")
+	assert.NotEmpty(t, out.APIResult)
 }
 
 func TestFiles_ListRevisions(t *testing.T) {

--- a/sharing.go
+++ b/sharing.go
@@ -2,6 +2,7 @@ package dropbox
 
 import (
 	"encoding/json"
+	"net/http"
 	"time"
 )
 
@@ -33,6 +34,7 @@ type CreateSharedLinkOutput struct {
 		Tag VisibilityType `json:".tag"`
 	} `json:"visibility"`
 	Expires time.Time `json:"expires,omitempty"`
+	Header  http.Header
 }
 
 // VisibilityType determines who can access the link.
@@ -49,12 +51,15 @@ const (
 
 // CreateSharedLink returns a shared link.
 func (c *Sharing) CreateSharedLink(in *CreateSharedLinkInput) (out *CreateSharedLinkOutput, err error) {
-	body, err := c.call("/sharing/create_shared_link", in)
+	body, hdr, err := c.call("/sharing/create_shared_link", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }

--- a/users.go
+++ b/users.go
@@ -2,6 +2,7 @@ package dropbox
 
 import (
 	"encoding/json"
+	"net/http"
 )
 
 // Users client for user accounts.
@@ -32,17 +33,21 @@ type GetAccountOutput struct {
 		FamiliarName string `json:"familiar_name"`
 		DisplayName  string `json:"display_name"`
 	} `json:"name"`
+	Header http.Header
 }
 
 // GetAccount returns information about a user's account.
 func (c *Users) GetAccount(in *GetAccountInput) (out *GetAccountOutput, err error) {
-	body, err := c.call("/users/get_account", in)
+	body, hdr, err := c.call("/users/get_account", in)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -63,17 +68,21 @@ type GetCurrentAccountOutput struct {
 		Tag string `json:".tag"`
 	} `json:"account_type"`
 	Country string `json:"country"`
+	Header  http.Header
 }
 
 // GetCurrentAccount returns information about the current user's account.
 func (c *Users) GetCurrentAccount() (out *GetCurrentAccountOutput, err error) {
-	body, err := c.call("/users/get_current_account", nil)
+	body, hdr, err := c.call("/users/get_current_account", nil)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }
 
@@ -84,16 +93,20 @@ type GetSpaceUsageOutput struct {
 		Used      uint64 `json:"used"`
 		Allocated uint64 `json:"allocated"`
 	} `json:"allocation"`
+	Header http.Header
 }
 
 // GetSpaceUsage returns space usage information for the current user's account.
 func (c *Users) GetSpaceUsage() (out *GetSpaceUsageOutput, err error) {
-	body, err := c.call("/users/get_space_usage", nil)
+	body, hdr, err := c.call("/users/get_space_usage", nil)
 	if err != nil {
 		return
 	}
 	defer body.Close()
 
 	err = json.NewDecoder(body).Decode(&out)
+	if err == nil {
+		out.Header = hdr
+	}
 	return
 }


### PR DESCRIPTION
The HTTP headers include interesting entries like X-Dropbox-Request-Id and
Dropbox-Api-Result for certain calls. This commit adds a Header field to the
output structs.
