### PR TITLE
Add missing path_display to file metadata

### DIFF
--- a/files.go
+++ b/files.go
@@ -80,6 +80,7 @@ type Metadata struct {
 	Tag            string           `json:".tag"`
 	Name           string           `json:"name"`
 	PathLower      string           `json:"path_lower"`
+	PathDisplay    string           `json:"path_display"`
 	ClientModified time.Time        `json:"client_modified"`
 	ServerModified time.Time        `json:"server_modified"`
 	Rev            string           `json:"rev"`


### PR DESCRIPTION
This field can be seen in [the documentation](https://www.dropbox.com/developers/documentation/http/documentation#files-get_metadata) but is not present in the corresponding Go struct. This PR adds it in. 
