### PR TITLE
Implemented upload session APIs (multi-part uploads)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 
-[![GoDoc](https://godoc.org/github.com/tj/go-dropbox?status.svg)](https://godoc.org/github.com/tj/go-dropbox) [![Build Status](https://semaphoreci.com/api/v1/projects/bc0bfd8b-73c9-45ba-b988-00f9e285e6ef/617305/badge.svg)](https://semaphoreci.com/tj/go-dropbox)
+[![GoDoc](https://godoc.org/github.com/tj/go-dropbox?status.svg)](https://godoc.org/github.com/tj/go-dropbox) [![Build Status](https://semaphoreci.com/api/v1/projects/bc0bfd8b-73c9-45ba-b988-00f9e285e6ef/617305/shields_badge.svg)](https://semaphoreci.com/tj/go-dropbox)
 
 # Dropbox
 

--- a/client.go
+++ b/client.go
@@ -47,8 +47,8 @@ func (c *Client) call(path string, in interface{}) (io.ReadCloser, error) {
 	return r, err
 }
 
-// download style endpoint.
-func (c *Client) download(path string, in interface{}, r io.Reader) (io.ReadCloser, int64, error) {
+// content download/upload style endpoint.
+func (c *Client) content(path string, in interface{}, r io.Reader) (io.ReadCloser, int64, error) {
 	url := "https://content.dropboxapi.com/2" + path
 
 	body, err := json.Marshal(in)
@@ -68,6 +68,17 @@ func (c *Client) download(path string, in interface{}, r io.Reader) (io.ReadClos
 	}
 
 	return c.do(req)
+}
+
+// content download/upload style endpoint with response body JSON decoding.
+func (c *Client) decodeContent(path string, in interface{}, r io.Reader, out interface{}) (err error) {
+	body, _, err := c.content(path, in, r)
+	if err != nil {
+		return
+	}
+	err = json.NewDecoder(body).Decode(out)
+	body.Close()
+	return
 }
 
 // perform the request.

--- a/files.go
+++ b/files.go
@@ -369,7 +369,7 @@ type UploadOutput struct {
 
 // Upload a file smaller than 150MB.
 func (c *Files) Upload(in *UploadInput) (out *UploadOutput, err error) {
-	err = c.decodeContent("/files/upload", in, in.Reader, out)
+	err = c.decodeContent("/files/upload", in, in.Reader, &out)
 	return
 }
 

--- a/files_test.go
+++ b/files_test.go
@@ -2,7 +2,6 @@ package dropbox
 
 import (
 	"bytes"
-	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -182,30 +181,4 @@ func TestFiles_ListRevisions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, out.Entries)
 	assert.False(t, out.IsDeleted)
-}
-
-func TestFiles_UploadSession(t *testing.T) {
-	c := client()
-	//880KB file
-	size := int64(880e3)
-	b := make([]byte, int(size))
-	_, err := rand.Read(b)
-	if err != nil {
-		t.Fatal("crypto fail")
-	}
-	noise := bytes.NewBuffer(b)
-	//upload in 200KB chunks
-	meta, err := c.Files.UploadSession(&UploadSessionInput{
-		Size:      size,
-		ChunkSize: 200e3,
-		Commit: UploadInput{
-			Mute:   true,
-			Mode:   WriteModeOverwrite,
-			Path:   "/noise.txt",
-			Reader: noise,
-		},
-	})
-
-	assert.NoError(t, err, "error session uploading file")
-	assert.Equal(t, meta.Size, size, "should be the correct size")
 }

--- a/files_test.go
+++ b/files_test.go
@@ -2,6 +2,7 @@ package dropbox
 
 import (
 	"bytes"
+	"crypto/rand"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -181,4 +182,30 @@ func TestFiles_ListRevisions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, out.Entries)
 	assert.False(t, out.IsDeleted)
+}
+
+func TestFiles_UploadSession(t *testing.T) {
+	c := client()
+	//880KB file
+	size := int64(880e3)
+	b := make([]byte, int(size))
+	_, err := rand.Read(b)
+	if err != nil {
+		t.Fatal("crypto fail")
+	}
+	noise := bytes.NewBuffer(b)
+	//upload in 200KB chunks
+	meta, err := c.Files.UploadSession(&UploadSessionInput{
+		Size:      size,
+		ChunkSize: 200e3,
+		Commit: UploadInput{
+			Mute:   true,
+			Mode:   WriteModeOverwrite,
+			Path:   "/noise.txt",
+			Reader: noise,
+		},
+	})
+
+	assert.NoError(t, err, "error session uploading file")
+	assert.Equal(t, meta.Size, size, "should be the correct size")
 }


### PR DESCRIPTION
Changes
- implemented upload session APIs (multi-part uploads)
- ~~implemented auto-handled upload session method `UploadSession()`~~ (see go-dropy)
- renamed internal `download()` to `content()` ("Content-upload endpoints" and "Content-download endpoints")
- added internal `decodeContent()` helper
- fixed `PermanentlyDelete` endpoint path (not sure if it was incorrect on purpose?)

Notes
1. Methods should probably use value parameters, as pointer parameters allow property changes after the call has been made. Also, it's good practise to use values where possible. However, I thought it was more important to follow the current method layout.
2. As an alternate API to reduce the size of `files.go`, the raw upload session methods (start/append/finish) could be moved to `files_upload_session.go` and then would become `Files.UploadSession.Start()`, `.Append()`, `.Finish()` - though we'd have to rename `UploadSession()` to something else.
3. As an additional feature, we could add a `PerformRetries bool` so if any chunk failed, it would be retransmitted. This would require a `ChunkSize` buffer though to hold data in case of failure and maybe the Dropbox API doesn't fail that often so it might not be worth it...
