### PR TITLE
Parse Metadata content_hash and add ContentHash(io.Reader) for comparison

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,9 +94,8 @@ func (c *Client) do(req *http.Request) (io.ReadCloser, int64, error) {
 		if b, err := ioutil.ReadAll(res.Body); err == nil {
 			e.Summary = string(b)
 			return nil, 0, e
-		} else {
-			return nil, 0, err
 		}
+		return nil, 0, err
 	}
 
 	if err := json.NewDecoder(res.Body).Decode(e); err != nil {

--- a/files_test.go
+++ b/files_test.go
@@ -5,8 +5,10 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/ungerik/go-dry"
 )
 
 func TestFiles_Upload(t *testing.T) {
@@ -181,4 +183,14 @@ func TestFiles_ListRevisions(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, out.Entries)
 	assert.False(t, out.IsDeleted)
+}
+
+func TestFiles_ContentHash(t *testing.T) {
+	data, err := dry.FileGetBytes("https://www.dropbox.com/static/images/developers/milky-way-nasa.jpg", time.Second*5)
+	assert.NoError(t, err)
+
+	hash, err := ContentHash(bytes.NewBuffer(data))
+	assert.NoError(t, err)
+
+	assert.Equal(t, "485291fa0ee50c016982abbfa943957bcd231aae0492ccbaa22c58e3997b35e0", hash)
 }


### PR DESCRIPTION
* Added `Metadata.ContentHash` field
* `ContentHash(r io.Reader)` returns the Dropbox content_hash for a io.Reader.
* `FileContentHash(filename string)` returns the Dropbox content_hash for a local file.

See [https://www.dropbox.com/developers/reference/content-hash](https://www.dropbox.com/developers/reference/content-hash)

`TestFiles_ContentHash` downloads 10MB reference file from the documentation: https://www.dropbox.com/static/images/developers/milky-way-nasa.jpg

